### PR TITLE
Update repository url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## [1.0.2](https://github.com/4Catalyzer/sass-tailwind-functions/compare/v1.0.1...v1.0.2) (2021-10-12)
+## [1.0.2](https://github.com/jquense/sass-tailwind-functions/compare/v1.0.1...v1.0.2) (2021-10-12)
 
 
 ### Bug Fixes
 
-* make theme behave closer to tailwind ([f6b668d](https://github.com/4Catalyzer/sass-tailwind-functions/commit/f6b668d67ce3a62b51acde05c496b8652900a0eb))
+* make theme behave closer to tailwind ([f6b668d](https://github.com/jquense/sass-tailwind-functions/commit/f6b668d67ce3a62b51acde05c496b8652900a0eb))
 
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/4Catalyzer/sass-tailwind-functions.git"
+    "url": "https://github.com/jquense/sass-tailwind-functions.git"
   },
   "author": "Jason Quense",
   "license": "MIT",


### PR DESCRIPTION
I updated the repo url in CHANGELOG.md as well, but this is really to fix the repo link from the [npm page](https://www.npmjs.com/package/sass-tailwind-functions), which currently gives a 404.

Thank you for this package!