### PR TITLE
fix: update to patched node-sass-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "color-convert": "^2.0.1",
     "color-string": "^1.6.0",
     "lodash": "^4.17.21",
-    "node-sass-utils": "^1.1.3",
+    "node-sass-utils": "https://github.com/sass-eyeglass/node-sass-utils#cdf561fe0e70cc45a75879143060b388566e6065",
     "tailwindcss": "^2.2.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5982,10 +5982,9 @@ node-releases@^1.1.61, node-releases@^1.1.75:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
   integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
 
-node-sass-utils@^1.1.3:
+"node-sass-utils@https://github.com/sass-eyeglass/node-sass-utils#cdf561fe0e70cc45a75879143060b388566e6065":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/node-sass-utils/-/node-sass-utils-1.1.3.tgz#ce99bcc7f96eec45eccbbd06f15f770d65a2d396"
-  integrity sha512-zSBvzcPeI8qY3fcJPXuRVYkyKssHyt0bBLKZ9TaYBn2dskJTjooIaI0yqHL6BylgMd3WPyt9DQD91vfds75xLA==
+  resolved "https://github.com/sass-eyeglass/node-sass-utils#cdf561fe0e70cc45a75879143060b388566e6065"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
This is needed to work with sass versions since 1.44, until [this issue is addressed](https://github.com/sass-eyeglass/node-sass-utils/issues/24).

Tests completed with sass 1.38, 1.46, and 1.58.3 (latest).

Edit: this is still incompatible with the new sass api methods, compile and compileAsync; trying to add support for those.